### PR TITLE
Update for batch_write and insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ Supported features:
 
 * Automatically generate the provided attribute-column field(s) of schema entity into the `filter`
   expression option of `GetRow` (see `c:EctoTablestore.Repo.one/2`) and `BatchGet` (see
-  `c:EctoTablestore.Repo.batch_get/1`) use `entity_full_match: true`, by default this option is
+  `c:EctoTablestore.Repo.batch_get/1`) when use `entity_full_match: true`, by default this option is
   `false`.
 
 * Automatically generate the provided attribute-column field(s) of schema entity into the
-  `condition` expression option of `BatchWrite`.
+  `condition` expression option of `BatchWrite` (see `c:EctoTablestore.Repo.batch_write/2`) when
+  use `entity_full_match: true`, by default this option is `false`.
 
 * Automatically map changeset's attribute-column field(s) into `UpdateRow` operation when call
   `c:EctoTablestore.Repo.update/2`:

--- a/lib/ecto_tablestore/adapter.ex
+++ b/lib/ecto_tablestore/adapter.ex
@@ -1404,6 +1404,7 @@ defmodule Ecto.Adapters.Tablestore do
     end
   end
 
+  @doc false
   def autogen_fields(schema) do
     case schema.__schema__(:autogenerate) do
       [{autogen_fields, {m, f, a}}] ->
@@ -1415,6 +1416,7 @@ defmodule Ecto.Adapters.Tablestore do
     end
   end
 
+  @doc false
   def autoupdate_fields(schema) do
     case schema.__schema__(:autoupdate) do
       [{autoupdate_fields, {m, f, a}}] ->

--- a/lib/ecto_tablestore/repo/batch_write.ex
+++ b/lib/ecto_tablestore/repo/batch_write.ex
@@ -1,0 +1,307 @@
+defmodule EctoTablestore.Repo.BatchWrite do
+  @moduledoc false
+
+  alias Ecto.Adapters.Tablestore
+  alias ExAliyunOts.Const.OperationType
+
+  require OperationType
+
+  @adapter Tablestore
+
+  def batch_write(repo, writes, options) do
+    {_adapter, meta} = Ecto.Repo.Registry.lookup(repo)
+
+    instance = meta.instance
+
+    {write_requests, structs_map} =
+      writes
+      |> Enum.map(&map_batch_writes(instance, &1))
+      |> Enum.unzip()
+
+
+    {prepared_requests, opers} =
+      write_requests
+      |> reduce_merge_map()
+      |> Enum.reduce({[], %{}}, fn {source, reqs}, {req_acc, oper_acc} ->
+        opers =
+          for req <- reqs do
+            case req.type do
+              OperationType.delete() -> :delete
+              OperationType.update() -> :update
+              OperationType.put() -> :put
+            end
+          end
+
+        {
+          [{source, reqs} | req_acc],
+          Map.put(oper_acc, source, opers)
+        }
+
+      end)
+
+    structs = reduce_merge_map(structs_map)
+
+    result = ExAliyunOts.batch_write(instance, prepared_requests, options)
+
+    case result do
+      {:ok, response} ->
+        {
+          :ok,
+          format_batch_write_response(response.tables, structs, opers)
+        }
+
+      _error ->
+        result
+    end
+  end
+
+  defp map_batch_writes(_instance, {:delete, deletes}) do
+    Enum.reduce(deletes, {%{}, %{}}, fn delete, {delete_acc, acc} ->
+      {source, pks, options, struct} = map_batch_write(:delete, delete) 
+      prepared_request = ExAliyunOts.write_delete(pks, options)
+
+      delete_acc = update_map_with_list(delete_acc, source, prepared_request)
+      acc = update_map_with_list(acc, source, struct)
+      {delete_acc, acc}
+    end)
+  end
+
+  defp map_batch_writes(instance, {:put, puts}) do
+    Enum.reduce(puts, {%{}, %{}}, fn put, {put_acc, acc} ->
+      {source, pks, attrs, options, struct} = map_batch_write(:put, instance, put)
+      prepared_request = ExAliyunOts.write_put(pks, attrs, options)
+
+      put_acc = update_map_with_list(put_acc, source, prepared_request)
+      acc = update_map_with_list(acc, source, struct)
+      {put_acc, acc}
+    end)
+  end
+
+  defp map_batch_writes(_instance, {:update, updates}) do
+    Enum.reduce(updates, {%{}, %{}}, fn update, {update_acc, acc} ->
+      {source, pks, options, struct} = map_batch_write(:update, update)
+      prepared_request = ExAliyunOts.write_update(pks, options)
+
+      update_acc = update_map_with_list(update_acc, source, prepared_request)
+      acc = update_map_with_list(acc, source, struct)
+      {update_acc, acc}
+    end)
+  end
+
+  defp map_batch_writes(_instance, item) do
+    raise("Invalid usecase - batch write with item: #{inspect(item)}")
+  end
+
+  defp map_batch_write(:delete, %{__meta__: _mate} = struct) do
+    map_batch_write(:delete, {struct, []})
+  end
+
+  defp map_batch_write(:delete, {%{__meta__: meta} = struct, options}) do
+    source = meta.schema.__schema__(:source)
+    pks = Tablestore.primary_key_as_string(struct)
+    options = Tablestore.generate_condition_options(struct, options)
+
+    {source, pks, options, struct}
+  end
+
+  defp map_batch_write(:delete, {schema, pks}) do
+    map_batch_write(:delete, {schema, pks, []})
+  end
+
+  defp map_batch_write(:delete, {schema, pks, options}) do
+    source = schema.__schema__(:source)
+    struct = struct(schema, pks)
+    pks = Tablestore.primary_key_as_string(schema, pks)
+
+    {source, pks, options, struct}
+  end
+
+  defp map_batch_write(:update, %Ecto.Changeset{valid?: true} = changeset) do
+    map_batch_write(:update, {changeset, []})
+  end
+
+  defp map_batch_write(:update, {%Ecto.Changeset{valid?: true} = changeset, options}) do
+    struct = changeset.data
+    meta = struct.__meta__
+    schema = meta.schema
+    source = schema.__schema__(:source)
+    dumper = schema.__schema__(:dump)
+
+    pks = Tablestore.primary_key_as_string(struct)
+
+    options = Tablestore.generate_condition_options(struct, options)
+
+    embeds = schema.__schema__(:embeds)
+    embeds = Ecto.Embedded.prepare(changeset, embeds, @adapter, :update)
+
+    changes = Map.merge(changeset.changes, embeds)
+    changes = dump_changes!(schema, changes, dumper)
+
+    autogen_fields = Tablestore.autoupdate_fields(schema)
+    changes = Keyword.merge(autogen_fields, changes)
+
+    attrs = Tablestore.map_attrs_to_update(schema, changes)
+
+    options = Keyword.merge(options, attrs)
+
+    struct =
+      changeset
+      |> load_changes(embeds, autogen_fields)
+      |> changeset_to_struct()
+
+    {source, pks, options, struct}
+  end
+
+  defp map_batch_write(:put, instance, {schema, pks, attrs, options}) do
+    struct = struct(schema, pks ++ attrs)
+    map_batch_write(:put, instance, {Ecto.Changeset.change(struct), options})
+  end
+
+  defp map_batch_write(:put, instance, %{__meta__: _meta} = struct) do
+    map_batch_write(:put, instance, {struct, []})
+  end
+
+  defp map_batch_write(:put, instance, {%{__meta__: _meta} = struct, options}) do
+    map_batch_write(:put, instance, {Ecto.Changeset.change(struct), options})
+  end
+
+  defp map_batch_write(:put, instance, %Ecto.Changeset{valid?: true} = changeset) do
+    map_batch_write(:put, instance, {changeset, []})
+  end
+
+  defp map_batch_write(:put, instance, {%Ecto.Changeset{valid?: true} = changeset, options}) do
+    struct = changeset.data
+    meta = changeset.data.__meta__
+    schema = meta.schema
+    source = schema.__schema__(:source)
+    dumper = schema.__schema__(:dump)
+    fields = schema.__schema__(:fields)
+
+    # in put we always merge the whole struct into the changeset as changes.
+    changeset = Ecto.Changeset.Relation.surface_changes(changeset, struct, fields)
+
+    embeds = schema.__schema__(:embeds)
+    embeds = Ecto.Embedded.prepare(changeset, embeds, @adapter, :insert)
+
+    changes = 
+      changeset.changes
+      |> Map.merge(embeds)
+      |> Map.take(fields)
+
+    changes = dump_changes!(schema, changes, dumper)
+
+    autogen_fields = Tablestore.autogen_fields(schema)
+    changes = Keyword.merge(autogen_fields, changes)
+
+    {pks, attrs, _autogenerate_id_name} = Tablestore.pks_and_attrs_to_put_row(instance, schema, changes)
+
+    struct =
+      changeset
+      |> load_changes(embeds, autogen_fields)
+      |> changeset_to_struct()
+
+    options = Tablestore.generate_condition_options(:put, struct, options)
+
+    {source, pks, attrs, options, struct}
+  end
+
+  defp map_batch_write(_, _instance, %Ecto.Changeset{valid?: false} = changeset) do
+    raise "Using invalid changeset: #{inspect(changeset)} in batch writes"
+  end
+
+  defp map_batch_write(_, _instance, {%Ecto.Changeset{valid?: false} = changeset, _options}) do
+    raise "Using invalid changeset: #{inspect(changeset)} in batch writes"
+  end
+
+  defp update_map_with_list(map, key, value) do
+    Map.update(map, key, [value], fn current ->
+      [value | current]
+    end)
+  end
+
+  defp format_batch_write_response(tables_in_response, structs, opers) do
+    Enum.reduce(tables_in_response, [], fn table, acc ->
+      table_name = table.table_name
+
+      structs_in_table = Map.get(structs, table_name)
+
+      opers_in_table = Map.get(opers, table_name, [])
+
+      results =
+        Enum.zip(
+          [opers_in_table, table.rows, structs_in_table]
+        )
+        |> Enum.reduce([], fn {oper, %{is_ok: is_ok, row: row} = response, struct}, oper_acc ->
+          # `row` should be:
+          #   pks only
+          #   no-pks but with atomic increment result
+          #   nil
+          return =
+            if is_ok == true do
+              struct = Tablestore.row_to_struct(struct, row)
+              {:ok, struct}
+            else
+              {:error, response}
+            end
+
+          Keyword.update(oper_acc, oper, [return], fn current ->
+            [return | current]
+          end)
+        end)
+      
+      schema = List.first(structs_in_table).__meta__.schema
+      Keyword.put(acc, schema, results)
+    end)
+  end
+
+  defp changeset_to_struct(%{data: struct}) do
+    struct
+  end
+
+  defp load_changes(changeset, embeds, autogen) do
+    %{data: data, changes: changes} = changeset
+
+    data =
+      data
+      |> merge_changes(changes)
+      |> Map.merge(embeds)
+      |> Map.merge(Map.new(autogen))
+
+    Map.put(changeset, :data, data)
+  end
+
+  defp merge_changes(data, changes) do
+    changes =
+      Enum.reduce(changes, changes, fn {key, _value}, changes ->
+        if Map.has_key?(data, key), do: changes, else: Map.delete(changes, key)
+      end)
+
+    Map.merge(data, changes)
+  end
+
+  defp reduce_merge_map(items) do
+    Enum.reduce(items, %{}, fn map, acc ->
+      Map.merge(acc, map, fn _key, list1, list2 ->
+        List.flatten([list1 | list2])
+      end)
+    end)
+  end
+
+  defp dump_changes!(schema, changes, dumper) do
+    for {field, value} <- changes do
+      {_field, type} = Map.fetch!(dumper, field)
+      {field, dump_field!(schema, type, field, value)}
+    end
+  end
+
+  defp dump_field!(schema, type, field, value) do
+    case Ecto.Type.adapter_dump(@adapter, type, value) do
+      {:ok, value} ->
+        value
+      :error ->
+        raise Ecto.ChangeError,
+              "value `#{inspect(value)}` for `#{schema}.#{field}` does not match type #{inspect type}"
+    end
+  end
+
+end

--- a/test/hashids_test.exs
+++ b/test/hashids_test.exs
@@ -87,11 +87,11 @@ defmodule EctoTablestore.HashidsTest do
 
     writes = [
       delete: [
-        saved_p0,
+        {saved_p0, entity_full_match: true},
         {Post, [keyid: saved_p1.keyid], condition: condition(:ignore)}
       ],
       update: [
-        {changeset_post2, return_type: :pk}
+        {changeset_post2, entity_full_match: true, return_type: :pk}
       ],
       put: [
         {p3, condition: condition(:expect_not_exist), return_type: :pk}

--- a/test/support/test_schema.ex
+++ b/test/support/test_schema.ex
@@ -104,8 +104,9 @@ defmodule EctoTablestore.TestSchema.User4 do
 
   tablestore_schema "test_embed_user4" do
     field(:id, :string, primary_key: true)
+    field(:count, :integer)
 
-    embeds_many :cars, Car, primary_key: false do
+    embeds_many :cars, Car, primary_key: false, on_replace: :delete do
       field(:name, :string)
       field(:status, Ecto.Enum, values: [:foo, :bar, :baz])
     end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -51,7 +51,10 @@ defmodule EctoTablestore.TransactionTest do
     {status, _result} =
       TestRepo.batch_write(
         [
-          update: [c1, c2]
+          update: [
+            {c1, condition: condition(:expect_exist)},
+            {c2, condition: condition(:expect_exist)}
+          ]
         ],
         transaction_id: transaction_id
       )


### PR DESCRIPTION
起因：

假设定义如下schema

```
defmodule EctoTablestore.TestSchema do
  use EctoTablestore.Schema

  tablestore_schema "test_schema" do
    field(:id, :string, primary_key: true)
    embeds_many :items, Items, primary_key: false, on_replace: :delete do
      field(:name, :string)
      field(:status, Ecto.Enum, values: [:foo, :bar, :baz])
    end
    ...
  end
end

```

当TestSchema定义了embeds_many，使用`Repo.batch_write/2`做类似写入操作时:

```
Repo.batch_write([
  put: [
     %TestSchema{id: "1"}
  ]
])
```

在此PR之前的默认行为，会将schema中提供的非nil的属性列全部调整格式化之后，用于条件更新，但是在ecto处理embeds_many的默认值会是"`[]`"（对应:items字段），这样自动构造的条件更新将会出现非预期的情况，导致无法完成最直接的PutRow操作，由于我们在读取操作（Repo.one/2，Repo.batch_get/1）已经新增可选项`entity_full_match: true`支持根据schema实例所提供的属性列构造filter，所以在这个PR中，我们做了如下调整：

1，`Repo.batch_write/2`中各个operation，新增可选项`entity_full_match: true`，以满足可能会希望使用schema提供的属性列用于条件更新，默认情况下该选项为false。但由于这个改动，之前只传递一struct或changset的用法，由于缺少必要的condition option，将会导致对应表下的batch_write失败，例如：

```
batch_write([
  delete: [
    schema_entity_1,
    schema_entity_2
  ]
```

使用该PR后需要根据业务显式提供`condition`选项，比如：

```
batch_write([
  delete: [
    {schema_entity_1, condition: condition(:ignore)}
    {schema_entity_2, condition: condition(:expect_exist)}
  ]
```

通常我们使用`ex_aliyun_ots`的时候，都会要求显式提供`condition`选项。

2，修复`Repo.batch_write/2`传入的changeset/struct，使用embeds_many或embeds_one对应的struct时，正确地有效将embeds内容解析为合法json encode内容；

3，如下2种情况下操作某张表有定义服务端[自增主键](https://help.aliyun.com/document_detail/47745.html)，可以不用显式提供`condition`选项:

  1. `Repo.batch_write/2`时PutRow操作
  2. `Repo.insert/2`操作
  
因为定义了某张表含有服务端自增主键，在插入一行操作时，服务端只接受`condition: condition(:ignore)`，据此我们可统一处理，简化`condition`选项传入；

4，改进Repo在insert/update/delete/batch_write操作时对`condition`选项的文档描述；

5，将原有使用`String.to_atom/1`地方，全部替换使用`String.to_existing_atom/1`。