### PR TITLE
Use scheme defined attribute fields into :columns_to_get opt

### DIFF
--- a/test/support/search.ex
+++ b/test/support/search.ex
@@ -148,6 +148,15 @@ defmodule EctoTablestore.Support.Search do
       |> TestRepo.insert(condition: condition(:expect_not_exist), return_type: :pk)
     end)
 
+    {:ok, _} =
+      ExAliyunOts.update_row(
+        @instance,
+        Student.__schema__(:source),
+        [{"partition_key", "b9"}],
+        put: [{"unknown1", "unknownfield1"}, {"unknown2", true}],
+        condition: condition(:expect_exist)
+      )
+
     Logger.info("waiting for indexing...")
     Process.sleep(35_000)
   end


### PR DESCRIPTION
Used for **all** READ operations:

- `Repo.batch_get/1`
- `Repo.get/3`
- `Repo.get_range/4`
- `Repo.one/2`
- `Repo.search/3`
- `Repo.stream/2`
- `Repo.stream_range/4`
- `Repo.stream_search/3`