### PR TITLE
Fix source link in docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -51,6 +51,7 @@ defmodule EctoTablestore.MixProject do
   defp docs do
     [
       main: "readme",
+      source_ref: "master",
       formatter_opts: [gfm: true],
       extras: [
         "README.md",


### PR DESCRIPTION
The view source link is broken due to the `exdoc` changing the default `:source_ref` to the `main` branch.