### PR TITLE
feat: support expand macro in Migration

### DIFF
--- a/test/migration_test.exs
+++ b/test/migration_test.exs
@@ -499,6 +499,27 @@ defmodule EctoTablestore.MigrationTest do
     assert old ++ [3, 4] == SchemaMigration.versions(@repo)
     {:ok, %{table_names: table_names}} = ExAliyunOts.list_table(@instance)
     assert true = Enum.all?(["migration_test1", "migration_test2"], &(&1 in table_names))
+
+    assert {:ok,
+            %{
+              table_meta: %{
+                primary_key: [%{name: "id", type: :INTEGER}, %{name: "name", type: :STRING}],
+                defined_column: [
+                  %{name: "col1", type: :DCT_INTEGER},
+                  %{name: "col2", type: :DCT_DOUBLE},
+                  %{name: "col3", type: :DCT_BOOLEAN},
+                  %{name: "col4", type: :DCT_STRING},
+                  %{name: "col5", type: :DCT_BLOB}
+                ]
+              },
+              index_metas: [
+                %{
+                  name: "migration_test1_index",
+                  primary_key: ["col1", "id"],
+                  defined_column: ["col2"]
+                }
+              ]
+            }} = ExAliyunOts.describe_table(@instance, "migration_test1")
   end
 
   test "with_repo: drop" do

--- a/test/support/migrations/search_index/6_create.exs
+++ b/test/support/migrations/search_index/6_create.exs
@@ -2,6 +2,13 @@ defmodule EctoTablestore.Repo.Migrations.Create do
   @moduledoc false
   use EctoTablestore.Migration
 
+  defmacrop timestamps do
+    quote do
+      field_schema_integer("inserted_at")
+      field_schema_integer("updated_at")
+    end
+  end
+
   def change do
     create table("migration_search_index_test") do
       add_pk :id, :integer, partition_key: true
@@ -11,10 +18,9 @@ defmodule EctoTablestore.Repo.Migrations.Create do
     create search_index("migration_search_index_test", "migration_search_index_test_index") do
       field_schema_keyword("name")
       field_schema_keyword("content")
-      field_schema_integer("inserted_at")
-      field_schema_integer("updated_at")
       field_schema_boolean("is_published")
       field_sort("name")
+      timestamps()
     end
   end
 end

--- a/test/support/migrations/success/3_name1.exs
+++ b/test/support/migrations/success/3_name1.exs
@@ -2,15 +2,21 @@ defmodule EctoTablestore.Repo.Migrations.Name1 do
   @moduledoc false
   use EctoTablestore.Migration
 
-  def change do
-    create table("migration_test1") do
-      add_pk :id, :integer, partition_key: true
-      add_pk :name, :string
+  defmacrop predefined_columns do
+    quote do
       add_column :col1, :integer
       add_column :col2, :double
       add_column :col3, :boolean
       add_column :col4, :string
       add_column :col5, :binary
+    end
+  end
+
+  def change do
+    create table("migration_test1") do
+      add_pk :id, :integer, partition_key: true
+      add_pk :name, :string
+      predefined_columns()
     end
 
     create secondary_index("migration_test1", "migration_test1_index") do


### PR DESCRIPTION
```elixir
defmacrop predefined_columns do
  quote do
    add_column :col1, :integer
    add_column :col2, :double
    add_column :col3, :boolean
    add_column :col4, :string
    add_column :col5, :binary
  end
end

defmacrop timestamps do
  quote do
    field_schema_integer("inserted_at")
    field_schema_integer("updated_at")
  end
end

def change do
  create table("migration_test1") do
    add_pk :id, :integer, partition_key: true
    add_pk :name, :string
    predefined_columns()
  end

  create secondary_index("migration_test1", "migration_test1_index") do
    add_pk :col1
    add_pk :id
    add_column :col2
  end

  create table("migration_search_index_test") do
    add_pk :id, :integer, partition_key: true
    add_pk :name, :string
  end

  create search_index("migration_search_index_test", "migration_search_index_test_index") do
    field_schema_keyword("name")
    field_schema_keyword("content")
    field_schema_boolean("is_published")
    field_sort("name")
    timestamps()
  end
end
```